### PR TITLE
support other swift library

### DIFF
--- a/HJResourceManager/HJResourceCipherCompress.h
+++ b/HJResourceManager/HJResourceCipherCompress.h
@@ -8,7 +8,6 @@
 //  Licensed under the MIT license.
 
 #import <Foundation/Foundation.h>
-#import <zlib.h>
 #import <HJResourceManager/HJResourceCipherProtocol.h>
 
 @interface HJResourceCipherCompress : NSObject <HJResourceCipherProtocol>

--- a/HJResourceManager/HJResourceCipherCompress.m
+++ b/HJResourceManager/HJResourceCipherCompress.m
@@ -8,6 +8,7 @@
 //  Licensed under the MIT license.
 
 #import "HJResourceCipherCompress.h"
+#import <zlib.h>
 
 @implementation HJResourceCipherCompress
 

--- a/HJResourceManager/HJResourceCipherGzip.h
+++ b/HJResourceManager/HJResourceCipherGzip.h
@@ -9,7 +9,6 @@
 
 #import <Foundation/Foundation.h>
 #import <libkern/OSAtomic.h>
-#import <zlib.h>
 #import <HJResourceManager/HJResourceCipherProtocol.h>
 
 @interface HJResourceCipherGzip : NSObject <HJResourceCipherProtocol>

--- a/HJResourceManager/HJResourceCipherGzip.m
+++ b/HJResourceManager/HJResourceCipherGzip.m
@@ -8,6 +8,7 @@
 //  Licensed under the MIT license.
 
 #import "HJResourceCipherGzip.h"
+#import <zlib.h>
 
 #define     kMinimumReadBufferSize      (1024*1024)
 


### PR DESCRIPTION
swift library need "use_framework" keyword on cocoapods.

fixed about this.